### PR TITLE
[YAI] More support to time-limited items

### DIFF
--- a/yaaccountinventory/src/addon_d.ipf/yaaccountinventory/yaaccountinventory.lua
+++ b/yaaccountinventory/src/addon_d.ipf/yaaccountinventory/yaaccountinventory.lua
@@ -1412,7 +1412,7 @@ function YAI_DRAW_ITEM(invItem, slot)
     icon:SetTooltipArg("accountwarehouse", invItem.type, invItem:GetIESID());
     SET_ITEM_TOOLTIP_TYPE(icon, itemCls.ClassID, itemCls, "accountwarehouse");
     
-    if invItem.hasLifeTime == true then
+    if invItem.hasLifeTime == true or TryGetProp(obj, 'ExpireDateTime', 'None') ~= 'None' then
         ICON_SET_ITEM_REMAIN_LIFETIME(icon, IT_ACCOUNT_WAREHOUSE);
         slot:SetFrontImage('clock_inven');
     else
@@ -1501,7 +1501,7 @@ function YAI_INSERT_ITEM_TO_TREE(frame, tree, invItem, itemCls, baseidcls, typeS
         icon:SetTooltipArg("accountwarehouse", invItem.type, invItem:GetIESID());
         SET_ITEM_TOOLTIP_TYPE(icon, itemCls.ClassID, itemCls, "accountwarehouse");
         
-        if invItem.hasLifeTime == true then
+        if invItem.hasLifeTime == true or TryGetProp(obj, 'ExpireDateTime', 'None') ~= 'None' then
             ICON_SET_ITEM_REMAIN_LIFETIME(icon, IT_ACCOUNT_WAREHOUSE);
             slot:SetFrontImage('clock_inven');
         else


### PR DESCRIPTION
not sure why IMC didn't use `invItem.hasLifeTime` this time.

only found in iTOS so far with items from these 2 events [[1]](https://treeofsavior.com/page/news/view.php?n=2061), [[2]](https://treeofsavior.com/page/news/view.php?n=2062)